### PR TITLE
build-image.yml: Use `eval` to parse `build.args` in `compose.yaml`

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,7 +46,7 @@ jobs:
           build_args=$(yq eval '.services.bot.build.args|to_entries[]|"\(.key)=\(.value)"' compose.yaml)
           delimiter="$(openssl rand -hex 8)"
           echo "build-args<<${delimiter}" >> $GITHUB_OUTPUT
-          echo "${build_args}" >> $GITHUB_OUTPUT
+          eval "echo \"${build_args}\"" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
           platforms=$(yq -o json '.services.bot.build.platforms' compose.yaml | jq -c)
           echo "platforms=${platforms}" >> $GITHUB_OUTPUT

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       args:
-        DOCKER_IMAGE: ubuntu
+        DOCKER_IMAGE: ${DOCKER_IMAGE:-ubuntu}
       platforms:
         - linux/amd64
         - linux/arm64


### PR DESCRIPTION
This change enables overriding `build.args` with environment variables when launching `docker compose`.